### PR TITLE
Fixed bug computing weights with tp_log

### DIFF
--- a/notebooks/18-Evaluation-Refactored.ipynb
+++ b/notebooks/18-Evaluation-Refactored.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "35ace44f",
+   "id": "81661dad",
    "metadata": {
     "Collapsed": "false"
    },
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d776d093",
+   "id": "15c56a06",
    "metadata": {
     "Collapsed": "false"
    },
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "558e0209",
+   "id": "4c8305ad",
    "metadata": {
     "Collapsed": "false"
    },
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "fe30645d",
+   "id": "7cd5466c",
    "metadata": {
     "Collapsed": "false"
    },
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38f553f9",
+   "id": "2bd8633d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "029c8d91",
+   "id": "a00d5178",
    "metadata": {
     "Collapsed": "false"
    },
@@ -123,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e80c3438",
+   "id": "ae9c0701",
    "metadata": {
     "Collapsed": "false"
    },
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1536d51a",
+   "id": "6c796e81",
    "metadata": {
     "Collapsed": "false"
    },
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "f523a064",
+   "id": "a02587a8",
    "metadata": {
     "Collapsed": "false"
    },
@@ -192,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "4f3863ba",
+   "id": "2bdcb398",
    "metadata": {
     "Collapsed": "false"
    },
@@ -220,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "3a482d10",
+   "id": "aaa55d63",
    "metadata": {
     "Collapsed": "false"
    },
@@ -232,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "5d864334",
+   "id": "cafc6293",
    "metadata": {
     "Collapsed": "false"
    },
@@ -249,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "16d8e247",
+   "id": "023a9995",
    "metadata": {
     "Collapsed": "false"
    },
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "3a6d2157",
+   "id": "7fdd7039",
    "metadata": {
     "Collapsed": "false"
    },
@@ -273,7 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "502a0f7c",
+   "id": "b5c1eb66",
    "metadata": {
     "Collapsed": "false"
    },
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "d00e6a64",
+   "id": "c1366b91",
    "metadata": {
     "Collapsed": "false"
    },
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "088e5190",
+   "id": "9fee35f4",
    "metadata": {
     "Collapsed": "false"
    },
@@ -330,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "459a4104",
+   "id": "7ef05b13",
    "metadata": {
     "Collapsed": "false"
    },
@@ -342,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "3422a3f9",
+   "id": "66360142",
    "metadata": {
     "Collapsed": "false"
    },
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8801bdb",
+   "id": "b2bd95b5",
    "metadata": {
     "Collapsed": "false"
    },
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "ac5cf178",
+   "id": "6875dc7c",
    "metadata": {
     "Collapsed": "false"
    },
@@ -377,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "85b2b051",
+   "id": "0fb9be95",
    "metadata": {
     "Collapsed": "false"
    },
@@ -390,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "ee3746e5",
+   "id": "a068c734",
    "metadata": {
     "Collapsed": "false"
    },
@@ -403,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a917d1d0",
+   "id": "a4a16597",
    "metadata": {
     "Collapsed": "false"
    },
@@ -414,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "f99d4b62",
+   "id": "cbc6d0fa",
    "metadata": {
     "Collapsed": "false"
    },
@@ -427,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "36384bfa",
+   "id": "0e794412",
    "metadata": {
     "Collapsed": "false"
    },
@@ -439,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "1fa3f948",
+   "id": "bb675965",
    "metadata": {
     "Collapsed": "false"
    },
@@ -452,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "7c9ec8be",
+   "id": "84ef140d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -464,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "c8a3c627",
+   "id": "e299ee68",
    "metadata": {
     "Collapsed": "false"
    },
@@ -476,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "bdc93073",
+   "id": "90286744",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1040,7 +1040,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6377999",
+   "id": "d2d4a49a",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1051,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "b4fdbe15",
+   "id": "824fbf11",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1063,7 +1063,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "ddd64ba1",
+   "id": "99e3627d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1075,7 +1075,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "c5cf864e",
+   "id": "77af86d9",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1088,7 +1088,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "b933d79e",
+   "id": "10ffca3e",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1100,7 +1100,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "8b045c79",
+   "id": "02c57505",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1112,7 +1112,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "8daa47e6",
+   "id": "a79f1d18",
    "metadata": {
     "Collapsed": "false",
     "collapsed": true,
@@ -1684,7 +1684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9209200b",
+   "id": "fef4e093",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1695,7 +1695,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "f24b579b",
+   "id": "5584ed6a",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1707,7 +1707,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "6486af66",
+   "id": "ea8e167f",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1722,7 +1722,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5bad1680",
+   "id": "029a6ef0",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1732,7 +1732,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1f27060",
+   "id": "cf5fa3c0",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1743,7 +1743,7 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "47d9e480",
+   "id": "522339b0",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1766,7 +1766,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "d96663ac",
+   "id": "f1b76ee9",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1789,7 +1789,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "dcfacb7c",
+   "id": "055e38b0",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1812,7 +1812,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "8db69bb9",
+   "id": "970a0fc5",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1834,7 +1834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1bbe096",
+   "id": "4e61954e",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1845,7 +1845,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "id": "339636d2",
+   "id": "db5546df",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1868,7 +1868,7 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "id": "14a8f5d2",
+   "id": "fd3bfa4d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1891,7 +1891,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b72bbd4a",
+   "id": "bb53bc9b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1901,7 +1901,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfb0999f",
+   "id": "d06286fe",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1913,7 +1913,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60ad577b",
+   "id": "4118a400",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1924,7 +1924,7 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "id": "cb62fd64",
+   "id": "4222e89d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2491,7 +2491,7 @@
   {
    "cell_type": "code",
    "execution_count": 74,
-   "id": "2142f1b2",
+   "id": "1058e6c1",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2532,7 +2532,7 @@
   {
    "cell_type": "code",
    "execution_count": 75,
-   "id": "b32f1dae",
+   "id": "6f41ba3d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2573,7 +2573,7 @@
   {
    "cell_type": "code",
    "execution_count": 82,
-   "id": "df60f1bb",
+   "id": "ebc33d0d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2614,7 +2614,7 @@
   {
    "cell_type": "code",
    "execution_count": 106,
-   "id": "38091f9f",
+   "id": "6abb3056",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2654,7 +2654,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fb67e5a",
+   "id": "575b2899",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2665,7 +2665,7 @@
   {
    "cell_type": "code",
    "execution_count": 76,
-   "id": "245f34ec",
+   "id": "83a72b2e",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2689,7 +2689,7 @@
   {
    "cell_type": "code",
    "execution_count": 77,
-   "id": "39bc11b4",
+   "id": "16814ed8",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2713,7 +2713,7 @@
   {
    "cell_type": "code",
    "execution_count": 78,
-   "id": "cfaf849d",
+   "id": "1e313198",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2737,7 +2737,7 @@
   {
    "cell_type": "code",
    "execution_count": 79,
-   "id": "1bb69b27",
+   "id": "bd134b58",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2761,7 +2761,7 @@
   {
    "cell_type": "code",
    "execution_count": 80,
-   "id": "8454a02a",
+   "id": "461f202f",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2785,7 +2785,7 @@
   {
    "cell_type": "code",
    "execution_count": 81,
-   "id": "464aa415",
+   "id": "8734cb05",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2808,7 +2808,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b102f4a8",
+   "id": "2197a409",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2819,7 +2819,7 @@
   {
    "cell_type": "code",
    "execution_count": 107,
-   "id": "44d06b0a",
+   "id": "505cbdda",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2831,7 +2831,7 @@
   {
    "cell_type": "code",
    "execution_count": 108,
-   "id": "66d1b349",
+   "id": "b30ee106",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2860,7 +2860,7 @@
   {
    "cell_type": "code",
    "execution_count": 109,
-   "id": "a4258aeb",
+   "id": "a9c53895",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2890,7 +2890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8372dc92",
+   "id": "b80b1bea",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2900,7 +2900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9dd90ec",
+   "id": "b8f53f71",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2909,7 +2909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01d3c73d",
+   "id": "f3e80d05",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2920,7 +2920,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49e9f24b",
+   "id": "196c0691",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2935,7 +2935,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "661b03d1",
+   "id": "ea258716",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2954,7 +2954,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "f70f4478",
+   "id": "a88e4487",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2968,7 +2968,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "b2373303",
+   "id": "ae39ede3",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2980,7 +2980,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a9fd6518",
+   "id": "d2f28143",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2992,7 +2992,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "624f18fd",
+   "id": "f1920009",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3499,7 +3499,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "ac7091e3",
+   "id": "0068919b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4032,7 +4032,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "0b26103f",
+   "id": "68b75a18",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4045,7 +4045,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "a70d4524",
+   "id": "4ee6f0d6",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4080,7 +4080,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "2f998113",
+   "id": "dd29861d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4466,7 +4466,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b91d32e0",
+   "id": "6c3eb578",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4477,7 +4477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "975c1b59",
+   "id": "73b5e6f2",
    "metadata": {
     "Collapsed": "false"
    },

--- a/notebooks/stephan_notebooks/20-Small-Stride.ipynb
+++ b/notebooks/stephan_notebooks/20-Small-Stride.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "1a0b32ca",
+   "execution_count": 2,
+   "id": "aeea1538",
    "metadata": {
     "Collapsed": "false"
    },
@@ -15,8 +15,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "3cfc89ad",
+   "execution_count": 3,
+   "id": "723f305b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -35,8 +35,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "d40f3e13",
+   "execution_count": 4,
+   "id": "0b0f84a2",
    "metadata": {
     "Collapsed": "false"
    },
@@ -47,8 +47,749 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
+   "id": "2f8c1326",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/envs/ilan/lib/python3.9/site-packages/xarray/core/indexing.py:1379: PerformanceWarning: Slicing is producing a large chunk. To accept the large\n",
+      "chunk and silence this warning, set the option\n",
+      "    >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):\n",
+      "    ...     array[indexer]\n",
+      "\n",
+      "To avoid creating the large chunks, set the option\n",
+      "    >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):\n",
+      "    ...     array[indexer]\n",
+      "  return self.array[key]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading data\n",
+      "[0.02]\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_dir = '/home/jupyter/data/'\n",
+    "\n",
+    "args = {'tigge_dir':data_dir+'tigge/32km/',\n",
+    "    'tigge_vars':['total_precipitation'],#, 'total_column_water_ens10', '2m_temperature', 'convective_available_potential_energy', 'convective_inhibition'],\n",
+    "    'mrms_dir':data_dir + f'mrms/4km/RadarOnly_QPE_06H/',\n",
+    "    'rq_fn':data_dir + f'mrms/4km/RadarQuality.nc',\n",
+    "#     'const_fn':data_dir + 'tigge/32km/constants.nc',\n",
+    "#     'const_vars':['orog', 'lsm'],\n",
+    "    'data_period':('2018-01', '2018-12'),\n",
+    "#     'val_days':5,\n",
+    "    'split':'train',\n",
+    "#     'pure_sr_ratio':8, \n",
+    "    'tp_log':0.01, \n",
+    "    'scale':True,\n",
+    "#     'ensemble_mode':'random',\n",
+    "    'pad_tigge':15,\n",
+    "    'pad_tigge_channel': True,\n",
+    "    'idx_stride':1,\n",
+    "    'first_days': 2\n",
+    "    }\n",
+    "\n",
+    "ds_train = TiggeMRMSDataset(**args)\n",
+    "\n",
+    "weights = ds_train.compute_weights()\n",
+    "\n",
+    "print(np.unique(weights))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a1974620",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.02, 0.02, 0.02, ..., 0.02, 0.02, 0.02])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "weights"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "775a0997",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> \u001b[0;32m/home/jupyter/repositories/nwp-downscale/notebooks/stephan_notebooks/src/dataloader.py\u001b[0m(323)\u001b[0;36mcompute_weights\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32m    321 \u001b[0;31m        \u001b[0;31m# weights = np.clip(mean_precip, 0.01, 0.1)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m    322 \u001b[0;31m        \u001b[0;32mimport\u001b[0m \u001b[0mpdb\u001b[0m\u001b[0;34m;\u001b[0m \u001b[0mpdb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m--> 323 \u001b[0;31m        \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtp_log\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m    324 \u001b[0;31m            \u001b[0mthreshold\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlog_trans\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mthreshold\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtp_log\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m    325 \u001b[0;31m            \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcat_bins\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "ipdb>  c\n"
+     ]
+    }
+   ],
+   "source": [
+    "weights = ds_train.compute_weights()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e0b3d6f0",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/envs/ilan/lib/python3.9/site-packages/xarray/core/indexing.py:1379: PerformanceWarning: Slicing is producing a large chunk. To accept the large\n",
+      "chunk and silence this warning, set the option\n",
+      "    >>> with dask.config.set(**{'array.slicing.split_large_chunks': False}):\n",
+      "    ...     array[indexer]\n",
+      "\n",
+      "To avoid creating the large chunks, set the option\n",
+      "    >>> with dask.config.set(**{'array.slicing.split_large_chunks': True}):\n",
+      "    ...     array[indexer]\n",
+      "  return self.array[key]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading data\n",
+      "> \u001b[0;32m/home/jupyter/repositories/nwp-downscale/notebooks/stephan_notebooks/src/dataloader.py\u001b[0m(323)\u001b[0;36mcompute_weights\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32m    321 \u001b[0;31m        \u001b[0;31m# weights = np.clip(mean_precip, 0.01, 0.1)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m    322 \u001b[0;31m        \u001b[0;32mimport\u001b[0m \u001b[0mpdb\u001b[0m\u001b[0;34m;\u001b[0m \u001b[0mpdb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_trace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m--> 323 \u001b[0;31m        \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtp_log\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mthreshold\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlog_trans\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mthreshold\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtp_log\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m    324 \u001b[0;31m        \u001b[0;32massert\u001b[0m \u001b[0mcompute_on_X\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'Not implemented.'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\u001b[0;32m    325 \u001b[0;31m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "ipdb>  c\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.02]\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_dir = '/home/jupyter/data/'\n",
+    "\n",
+    "args = {'tigge_dir':data_dir+'tigge/32km/',\n",
+    "    'tigge_vars':['total_precipitation'],#, 'total_column_water_ens10', '2m_temperature', 'convective_available_potential_energy', 'convective_inhibition'],\n",
+    "    'mrms_dir':data_dir + f'mrms/4km/RadarOnly_QPE_06H/',\n",
+    "    'rq_fn':data_dir + f'mrms/4km/RadarQuality.nc',\n",
+    "#     'const_fn':data_dir + 'tigge/32km/constants.nc',\n",
+    "#     'const_vars':['orog', 'lsm'],\n",
+    "    'data_period':('2018-01', '2018-12'),\n",
+    "#     'val_days':5,\n",
+    "    'split':'train',\n",
+    "#     'pure_sr_ratio':8, \n",
+    "#     'tp_log':0.01, \n",
+    "    'scale':True,\n",
+    "#     'ensemble_mode':'random',\n",
+    "    'pad_tigge':15,\n",
+    "    'pad_tigge_channel': True,\n",
+    "    'idx_stride':1,\n",
+    "    'first_days': 2\n",
+    "    }\n",
+    "\n",
+    "ds_train2 = TiggeMRMSDataset(**args)\n",
+    "\n",
+    "weights2 = ds_train2.compute_weights()\n",
+    "\n",
+    "print(np.unique(weights2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "d3991e4e",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([87276., 15311., 12986., 11865., 11067., 10530., 10482., 11925.,\n",
+       "        15191., 43587.]),\n",
+       " array([0.02 , 0.058, 0.096, 0.134, 0.172, 0.21 , 0.248, 0.286, 0.324,\n",
+       "        0.362, 0.4  ]),\n",
+       " <BarContainer object of 10 artists>)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAD4CAYAAADsKpHdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAQBUlEQVR4nO3df6zddX3H8edr7UTEFflRGLtlu3U0c4VolMo6NSZLTaiyrJiUpMsczdakkTDnlplZtj9csjSBZBmOZLA0sFGYGTRVQjPGJikzZhGLF0W7UhhXYVDp6FUQcQlo2Xt/nM8N515v7z3n3vaeU/p8JCfne97fz+d73t9vI6/7/X7POaaqkCTpZwbdgCRpOBgIkiTAQJAkNQaCJAkwECRJzdJBNzBf5557bo2Ojg66DUk6qTzyyCPfq6rlM607aQNhdHSUsbGxQbchSSeVJP99rHVeMpIkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBJ/E3lRdidNt9A3vvp6+/YmDvLUmz8QxBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJQI+BkOSPkxxI8p9J/inJm5OcneSBJE+257O6xl+XZDzJE0ku76pfmmR/W3dTkrT6aUnubvV9SUaP+55KkmY1ZyAkGQH+EFhTVZcAS4BNwDZgb1WtAva21yRZ3dZfDKwHbk6ypG3uFmArsKo91rf6FuDFqroIuBG44bjsnSSpZ71eMloKnJ5kKfAW4DlgA7Czrd8JXNmWNwB3VdWrVfUUMA5cluQCYFlVPVRVBdwxbc7ktnYD6ybPHiRJi2POQKiq7wJ/BTwDHAZeqqovAudX1eE25jBwXpsyAjzbtYlDrTbSlqfXp8ypqqPAS8A503tJsjXJWJKxiYmJXvdRktSDXi4ZnUXnL/iVwC8AZyT52GxTZqjVLPXZ5kwtVO2oqjVVtWb58uWzNy5J6ksvl4w+BDxVVRNV9RPgC8D7gOfbZSDa85E2/hBwYdf8FXQuMR1qy9PrU+a0y1JnAi/MZ4ckSfPTSyA8A6xN8pZ2XX8dcBDYA2xuYzYD97blPcCm9smhlXRuHj/cLiu9nGRt287V0+ZMbmsj8GC7zyBJWiRL5xpQVfuS7Aa+DhwFvgHsAN4K7EqyhU5oXNXGH0iyC3isjb+2ql5rm7sGuB04Hbi/PQBuA+5MMk7nzGDTcdk7SVLP5gwEgKr6DPCZaeVX6ZwtzDR+O7B9hvoYcMkM9VdogSJJGgy/qSxJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNT0FQpK3Jdmd5PEkB5P8epKzkzyQ5Mn2fFbX+OuSjCd5IsnlXfVLk+xv625KklY/Lcndrb4vyehx31NJ0qx6PUP4G+Bfq+odwLuAg8A2YG9VrQL2ttckWQ1sAi4G1gM3J1nStnMLsBVY1R7rW30L8GJVXQTcCNywwP2SJPVpzkBIsgz4IHAbQFX9uKp+AGwAdrZhO4Er2/IG4K6qerWqngLGgcuSXAAsq6qHqqqAO6bNmdzWbmDd5NmDJGlx9HKG8HZgAviHJN9IcmuSM4Dzq+owQHs+r40fAZ7tmn+o1Uba8vT6lDlVdRR4CThneiNJtiYZSzI2MTHR4y5KknrRSyAsBd4D3FJV7wb+l3Z56Bhm+su+ZqnPNmdqoWpHVa2pqjXLly+fvWtJUl96CYRDwKGq2tde76YTEM+3y0C05yNd4y/smr8CeK7VV8xQnzInyVLgTOCFfndGkjR/cwZCVf0P8GySX2mldcBjwB5gc6ttBu5ty3uATe2TQyvp3Dx+uF1WejnJ2nZ/4Oppcya3tRF4sN1nkCQtkqU9jvsE8LkkbwK+A/wenTDZlWQL8AxwFUBVHUiyi05oHAWurarX2nauAW4HTgfubw/o3LC+M8k4nTODTQvcL0lSn3oKhKp6FFgzw6p1xxi/Hdg+Q30MuGSG+iu0QJEkDYbfVJYkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBsHTQDUjSyWh0230De++nr7/ihGzXMwRJEmAgSJIaA0GSBBgIkqTGQJAkAX0EQpIlSb6R5J/b67OTPJDkyfZ8VtfY65KMJ3kiyeVd9UuT7G/rbkqSVj8tyd2tvi/J6HHcR0lSD/o5Q/gkcLDr9TZgb1WtAva21yRZDWwCLgbWAzcnWdLm3AJsBVa1x/pW3wK8WFUXATcCN8xrbyRJ89ZTICRZAVwB3NpV3gDsbMs7gSu76ndV1atV9RQwDlyW5AJgWVU9VFUF3DFtzuS2dgPrJs8eJEmLo9czhM8Cfwr8X1ft/Ko6DNCez2v1EeDZrnGHWm2kLU+vT5lTVUeBl4BzpjeRZGuSsSRjExMTPbYuSerFnIGQ5DeBI1X1SI/bnOkv+5qlPtucqYWqHVW1pqrWLF++vMd2JEm96OWnK94P/FaSjwBvBpYl+Ufg+SQXVNXhdjnoSBt/CLiwa/4K4LlWXzFDvXvOoSRLgTOBF+a5T5KkeZjzDKGqrquqFVU1Sudm8YNV9TFgD7C5DdsM3NuW9wCb2ieHVtK5efxwu6z0cpK17f7A1dPmTG5rY3uPnzpDkCSdOAv5cbvrgV1JtgDPAFcBVNWBJLuAx4CjwLVV9Vqbcw1wO3A6cH97ANwG3JlknM6ZwaYF9CVJmoe+AqGqvgR8qS1/H1h3jHHbge0z1MeAS2aov0ILFEnSYPhNZUkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpmTMQklyY5N+THExyIMknW/3sJA8kebI9n9U157ok40meSHJ5V/3SJPvbupuSpNVPS3J3q+9LMnoC9lWSNItezhCOAn9SVb8KrAWuTbIa2AbsrapVwN72mrZuE3AxsB64OcmStq1bgK3AqvZY3+pbgBer6iLgRuCG47BvkqQ+zBkIVXW4qr7ell8GDgIjwAZgZxu2E7iyLW8A7qqqV6vqKWAcuCzJBcCyqnqoqgq4Y9qcyW3tBtZNnj1IkhZHX/cQ2qWcdwP7gPOr6jB0QgM4rw0bAZ7tmnao1Uba8vT6lDlVdRR4CThnhvffmmQsydjExEQ/rUuS5tBzICR5K/B54I+q6oezDZ2hVrPUZ5sztVC1o6rWVNWa5cuXz9WyJKkPPQVCkp+lEwafq6ovtPLz7TIQ7flIqx8CLuyavgJ4rtVXzFCfMifJUuBM4IV+d0aSNH+9fMoowG3Awar6665Ve4DNbXkzcG9XfVP75NBKOjePH26XlV5OsrZt8+ppcya3tRF4sN1nkCQtkqU9jHk/8LvA/iSPttqfAdcDu5JsAZ4BrgKoqgNJdgGP0fmE0rVV9Vqbdw1wO3A6cH97QCdw7kwyTufMYNPCdkuS1K85A6Gq/oOZr/EDrDvGnO3A9hnqY8AlM9RfoQWKJGkw/KayJAkwECRJjYEgSQIMBElSYyBIkoDePnaq42h0230Ded+nr79iIO8r6eRhIEg6qQ3qj6w3Ii8ZSZIAA0GS1BgIkiTAQJAkNd5UPkUM8sabn3CSTg6eIUiSAANBktR4yUgnnF/Ge+PzuwBvDJ4hSJIAzxD0BuaZidQfA0E6zrx8opOVl4wkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQMUSAkWZ/kiSTjSbYNuh9JOtUMRSAkWQL8LfBhYDXw20lWD7YrSTq1DEUgAJcB41X1nar6MXAXsGHAPUnSKWXpoBtoRoBnu14fAn5t+qAkW4Gt7eWPkjyxCL3Nx7nA9wbdxCzsb2GGvT8Y/h7tbwFyw4L6+6VjrRiWQMgMtfqpQtUOYMeJb2dhkoxV1ZpB93Es9rcww94fDH+P9rcwJ6q/YblkdAi4sOv1CuC5AfUiSaekYQmErwGrkqxM8iZgE7BnwD1J0illKC4ZVdXRJH8A/BuwBPj7qjow4LYWYtgva9nfwgx7fzD8PdrfwpyQ/lL1U5fqJUmnoGG5ZCRJGjADQZIEGAh9m+snNtJxU1v/rSTv6Vr3dJL9SR5NMjag/t6R5KEkryb5VD9zh6C/YTh+v9P+Xb+V5CtJ3tXr3CHobxiO34bW26NJxpJ8oNe5Q9DfwI9f17j3JnktycZ+586qqnz0+KBzw/vbwNuBNwHfBFZPG/MR4H46361YC+zrWvc0cO6A+zsPeC+wHfhUP3MH2d8QHb/3AWe15Q9P/vsO0fGbsb8hOn5v5fV7l+8EHh+y4zdjf8Ny/LrGPQj8C7DxeB4/zxD608tPbGwA7qiOrwJvS3LBsPRXVUeq6mvAT/qdO+D+FkMv/X2lql5sL79K5zszPc0dcH+LoZf+flTtv2DAGbz+BdRhOX7H6m8x9HoMPgF8Hjgyj7mzMhD6M9NPbIz0MaaALyZ5pP0MxyD6OxFze7XQ9xi247eFztngfObOx0L6gyE5fkk+muRx4D7g9/uZO8D+YAiOX5IR4KPA3/U7txdD8T2Ek0gvP7Ex25j3V9VzSc4DHkjyeFV9eZH7OxFze7XQ9xia45fkN+j8B3fyGvNQHb8Z+oMhOX5VdQ9wT5IPAn8JfKjXuQu0kP5gOI7fZ4FPV9VryZThx+X4eYbQn15+YuOYY6pq8vkIcA+d07zF7u9EzO3Vgt5jWI5fkncCtwIbqur7/cwdYH9Dc/y6+vky8MtJzu137gD6G5bjtwa4K8nTwEbg5iRX9jh3bifqBskb8UHnjOo7wEpev3Fz8bQxVzD1pvLDrX4G8HNdy18B1i92f11j/4KpN5V7njug/obi+AG/CIwD75vvvg2ov2E5fhfx+k3b9wDfbf9bGZbjd6z+huL4TRt/O6/fVD4ux++47cyp8qDzKaL/onNH/89b7ePAx9ty6Pyf/Xwb2A+safW3t3+kbwIHJucOoL+fp/PXxA+BH7TlZceaOyz9DdHxuxV4EXi0PcZmmzss/Q3R8ft0e/9HgYeADwzZ8Zuxv2E5ftPG3k4LhON1/PzpCkkS4D0ESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSc3/AzNTHH3QoqQbAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(weights)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a26f876b",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([163217.,  15105.,   9920.,   8131.,   6935.,   6408.,   5228.,\n",
+       "          4636.,   4603.,   6037.]),\n",
+       " array([0.02 , 0.058, 0.096, 0.134, 0.172, 0.21 , 0.248, 0.286, 0.324,\n",
+       "        0.362, 0.4  ]),\n",
+       " <BarContainer object of 10 artists>)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAD4CAYAAADy46FuAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAXzklEQVR4nO3dcayd9X3f8fdn9tKSZBCDLymz2ewUdx2gVA2O4yVdlc4ddpsqphJIjpphrZasIJZ107IGFmlMiSzBVo0OaTCh4GFYFLBoMqxlLLFgHZpCDDcJiWMI5TZkcIMb39QupZsgNf3uj/O7yrk35z733nPsey/h/ZKOznO+z+/3nN95LPvj5/k95zypKiRJmstfW+4BSJJWNoNCktTJoJAkdTIoJEmdDApJUqfVyz2AM23t2rW1YcOG5R6GJL2ufPWrX/1BVY0NWvcTFxQbNmxgfHx8uYchSa8rSf7PXOs89SRJ6mRQSJI6GRSSpE4GhSSpk0EhSepkUEiSOhkUkqROBoUkqZNBIUnq9BP3zexRbbjhC8vyvt+9+QPL8r6SNJ95jyiS7E9yIsm3ZtU/muSZJMeS/Nu++o1JJtq67X31K5IcbetuS5JW/6kk97f6kSQb+vrsTvJse+w+I59YkrQoCzn1dDewo7+Q5FeAncA7q+oy4Pda/VJgF3BZ63N7klWt2x3AXmBTe0xvcw9wqqouAW4FbmnbOh+4CXgPsAW4KcmaoT6lJGlo8wZFVT0KnJxVvg64uapebW1OtPpO4L6qerWqngMmgC1JLgLOrarHqneT7nuAq/r6HGjLDwDb2tHGduBwVZ2sqlPAYWYFliTp7Bt2MvvngL/fThX9ryTvbvV1wAt97SZbbV1bnl2f0aeqTgMvARd0bOvHJNmbZDzJ+NTU1JAfSZI0yLBBsRpYA2wF/iVwsB0FZEDb6qgzZJ+Zxao7q2pzVW0eGxv4c+qSpCENGxSTwOeq53Hgr4C1rX5xX7v1wIutvn5Anf4+SVYD59E71TXXtiRJS2jYoPivwD8ASPJzwJuAHwCHgF3tSqaN9CatH6+q48DLSba2I49rgQfbtg4B01c0XQ080uYxvghcmWRNm8S+stUkSUto3u9RJPks8H5gbZJJelci7Qf2t0tmfwjsbv+4H0tyEHgKOA1cX1WvtU1dR+8KqnOAh9oD4C7g3iQT9I4kdgFU1ckknwKeaO0+WVWzJ9UlSWfZvEFRVR+aY9WH52i/D9g3oD4OXD6g/gpwzRzb2k8vlCRJy8Sf8JAkdTIoJEmdDApJUieDQpLUyaCQJHUyKCRJnQwKSVIng0KS1MmgkCR1MigkSZ0MCklSJ4NCktTJoJAkdTIoJEmdDApJUieDQpLUad6gSLI/yYl2N7vZ6z6WpJKs7avdmGQiyTNJtvfVr0hytK27rd0SlXbb1Ptb/UiSDX19did5tj12I0lacgs5orgb2DG7mORi4B8Cz/fVLqV3K9PLWp/bk6xqq+8A9tK7j/amvm3uAU5V1SXArcAtbVvn07vt6nuALcBN7d7ZkqQlNG9QVNWj9O5lPdutwO8C1VfbCdxXVa9W1XPABLAlyUXAuVX1WLu39j3AVX19DrTlB4Bt7WhjO3C4qk5W1SngMAMCS5J0dg01R5Hkg8D3quobs1atA17oez3Zauva8uz6jD5VdRp4CbigY1uDxrM3yXiS8ampqWE+kiRpDosOiiRvBj4B/OtBqwfUqqM+bJ+Zxao7q2pzVW0eGxsb1ESSNKRhjih+FtgIfCPJd4H1wNeS/Ay9//Vf3Nd2PfBiq68fUKe/T5LVwHn0TnXNtS1J0hJadFBU1dGqurCqNlTVBnr/oL+rqv4EOATsalcybaQ3af14VR0HXk6ytc0/XAs82DZ5CJi+oulq4JE2j/FF4Moka9ok9pWtJklaQqvna5Dks8D7gbVJJoGbququQW2r6liSg8BTwGng+qp6ra2+jt4VVOcAD7UHwF3AvUkm6B1J7GrbOpnkU8ATrd0nq2rQpLok6SyaNyiq6kPzrN8w6/U+YN+AduPA5QPqrwDXzLHt/cD++cYoSTp7/Ga2JKmTQSFJ6mRQSJI6GRSSpE4GhSSpk0EhSepkUEiSOhkUkqROBoUkqZNBIUnqZFBIkjoZFJKkTgaFJKmTQSFJ6mRQSJI6GRSSpE7zBkWS/UlOJPlWX+3fJfl2km8m+XySt/WtuzHJRJJnkmzvq1+R5Ghbd1u7JSrttqn3t/qRJBv6+uxO8mx7TN8uVZK0hBZyRHE3sGNW7TBweVW9E/gj4EaAJJfSu5XpZa3P7UlWtT53AHvp3Ud7U9829wCnquoS4Fbglrat84GbgPcAW4Cb2r2zJUlLaN6gqKpH6d3Lur/2pao63V5+BVjflncC91XVq1X1HDABbElyEXBuVT1WVQXcA1zV1+dAW34A2NaONrYDh6vqZFWdohdOswNLknSWnYk5it8GHmrL64AX+tZNttq6tjy7PqNPC5+XgAs6tiVJWkIjBUWSTwCngc9MlwY0q476sH1mj2NvkvEk41NTU92DliQtytBB0SaXfwP4rXY6CXr/67+4r9l64MVWXz+gPqNPktXAefROdc21rR9TVXdW1eaq2jw2NjbsR5IkDTBUUCTZAXwc+GBV/b++VYeAXe1Kpo30Jq0fr6rjwMtJtrb5h2uBB/v6TF/RdDXwSAueLwJXJlnTJrGvbDVJ0hJaPV+DJJ8F3g+sTTJJ70qkG4GfAg63q1y/UlUfqapjSQ4CT9E7JXV9Vb3WNnUdvSuozqE3pzE9r3EXcG+SCXpHErsAqupkkk8BT7R2n6yqGZPqkqSzb96gqKoPDSjf1dF+H7BvQH0cuHxA/RXgmjm2tR/YP98YJUlnj9/MliR1MigkSZ0MCklSJ4NCktTJoJAkdTIoJEmdDApJUieDQpLUyaCQJHUyKCRJnQwKSVIng0KS1MmgkCR1MigkSZ0MCklSJ4NCktTJoJAkdZo3KJLsT3Iiybf6aucnOZzk2fa8pm/djUkmkjyTZHtf/YokR9u629q9s2n3176/1Y8k2dDXZ3d7j2eTTN9XW5K0hBZyRHE3sGNW7Qbg4araBDzcXpPkUnr3vL6s9bk9yarW5w5gL7CpPaa3uQc4VVWXALcCt7RtnU/v/tzvAbYAN/UHkiRpacwbFFX1KHByVnkncKAtHwCu6qvfV1WvVtVzwASwJclFwLlV9VhVFXDPrD7T23oA2NaONrYDh6vqZFWdAg7z44ElSTrLhp2jeHtVHQdozxe2+jrghb52k622ri3Prs/oU1WngZeACzq29WOS7E0ynmR8ampqyI8kSRrkTE9mZ0CtOurD9plZrLqzqjZX1eaxsbEFDVSStDDDBsX32+kk2vOJVp8ELu5rtx54sdXXD6jP6JNkNXAevVNdc21LkrSEhg2KQ8D0VUi7gQf76rvalUwb6U1aP95OT72cZGubf7h2Vp/pbV0NPNLmMb4IXJlkTZvEvrLVJElLaPV8DZJ8Fng/sDbJJL0rkW4GDibZAzwPXANQVceSHASeAk4D11fVa21T19G7guoc4KH2ALgLuDfJBL0jiV1tWyeTfAp4orX7ZFXNnlSXJJ1l8wZFVX1ojlXb5mi/D9g3oD4OXD6g/gotaAas2w/sn2+MkqSzx29mS5I6GRSSpE4GhSSpk0EhSepkUEiSOhkUkqROBoUkqZNBIUnqZFBIkjoZFJKkTgaFJKmTQSFJ6mRQSJI6GRSSpE4GhSSpk0EhSeo0UlAk+edJjiX5VpLPJvnpJOcnOZzk2fa8pq/9jUkmkjyTZHtf/YokR9u629rtUmm3VL2/1Y8k2TDKeCVJizd0UCRZB/xTYHNVXQ6soncb0xuAh6tqE/Bwe02SS9v6y4AdwO1JVrXN3QHspXeP7U1tPcAe4FRVXQLcCtwy7HglScMZ9dTTauCcJKuBNwMvAjuBA239AeCqtrwTuK+qXq2q54AJYEuSi4Bzq+qxqirgnll9prf1ALBt+mhDkrQ0hg6Kqvoe8HvA88Bx4KWq+hLw9qo63tocBy5sXdYBL/RtYrLV1rXl2fUZfarqNPAScMHssSTZm2Q8yfjU1NSwH0mSNMAop57W0Psf/0bgbwJvSfLhri4DatVR7+ozs1B1Z1VtrqrNY2Nj3QOXJC3KKKeefhV4rqqmquovgc8B7wW+304n0Z5PtPaTwMV9/dfTO1U12ZZn12f0aae3zgNOjjBmSdIijRIUzwNbk7y5zRtsA54GDgG7W5vdwINt+RCwq13JtJHepPXj7fTUy0m2tu1cO6vP9LauBh5p8xiSpCWyetiOVXUkyQPA14DTwNeBO4G3AgeT7KEXJte09seSHASeau2vr6rX2uauA+4GzgEeag+Au4B7k0zQO5LYNex4JUnDGTooAKrqJuCmWeVX6R1dDGq/D9g3oD4OXD6g/gotaCRJy8NvZkuSOhkUkqROBoUkqZNBIUnqZFBIkjoZFJKkTgaFJKmTQSFJ6mRQSJI6GRSSpE4GhSSpk0EhSepkUEiSOhkUkqROBoUkqZNBIUnqZFBIkjqNFBRJ3pbkgSTfTvJ0kr+X5Pwkh5M8257X9LW/MclEkmeSbO+rX5HkaFt3W7t3Nu3+2ve3+pEkG0YZryRp8UY9ovgPwP+oqp8HfgF4GrgBeLiqNgEPt9ckuZTePa8vA3YAtydZ1bZzB7AX2NQeO1p9D3Cqqi4BbgVuGXG8kqRFGjookpwL/DJwF0BV/bCq/gzYCRxozQ4AV7XlncB9VfVqVT0HTABbklwEnFtVj1VVAffM6jO9rQeAbdNHG5KkpTHKEcU7gCngPyf5epJPJ3kL8PaqOg7Qni9s7dcBL/T1n2y1dW15dn1Gn6o6DbwEXDB7IEn2JhlPMj41NTXCR5IkzTZKUKwG3gXcUVW/CPxf2mmmOQw6EqiOelefmYWqO6tqc1VtHhsb6x61JGlRRgmKSWCyqo601w/QC47vt9NJtOcTfe0v7uu/Hnix1dcPqM/ok2Q1cB5wcoQxS5IWaeigqKo/AV5I8ndaaRvwFHAI2N1qu4EH2/IhYFe7kmkjvUnrx9vpqZeTbG3zD9fO6jO9rauBR9o8hiRpiawesf9Hgc8keRPwHeAf0wufg0n2AM8D1wBU1bEkB+mFyWng+qp6rW3nOuBu4BzgofaA3kT5vUkm6B1J7BpxvJKkRRopKKrqSWDzgFXb5mi/D9g3oD4OXD6g/gotaCRJy8NvZkuSOhkUkqROBoUkqZNBIUnqZFBIkjoZFJKkTgaFJKmTQSFJ6mRQSJI6GRSSpE4GhSSpk0EhSepkUEiSOhkUkqROBoUkqZNBIUnqNHJQJFmV5OtJ/lt7fX6Sw0mebc9r+tremGQiyTNJtvfVr0hytK27rd0SlXbb1Ptb/UiSDaOOV5K0OGfiiOJ3gKf7Xt8APFxVm4CH22uSXErvVqaXATuA25Osan3uAPbSu4/2prYeYA9wqqouAW4FbjkD45UkLcJIQZFkPfAB4NN95Z3AgbZ8ALiqr35fVb1aVc8BE8CWJBcB51bVY1VVwD2z+kxv6wFg2/TRhiRpaYx6RPH7wO8Cf9VXe3tVHQdozxe2+jrghb52k622ri3Prs/oU1WngZeAC2YPIsneJONJxqempkb8SJKkfkMHRZLfAE5U1VcX2mVArTrqXX1mFqrurKrNVbV5bGxsgcORJC3E6hH6vg/4YJJfB34aODfJfwG+n+SiqjreTiudaO0ngYv7+q8HXmz19QPq/X0mk6wGzgNOjjBmSdIiDX1EUVU3VtX6qtpAb5L6kar6MHAI2N2a7QYebMuHgF3tSqaN9CatH2+np15OsrXNP1w7q8/0tq5u7/FjRxSSpLNnlCOKudwMHEyyB3geuAagqo4lOQg8BZwGrq+q11qf64C7gXOAh9oD4C7g3iQT9I4kdp2F8UqSOpyRoKiqPwT+sC3/KbBtjnb7gH0D6uPA5QPqr9CCRpK0PPxmtiSpk0EhSepkUEiSOhkUkqROBoUkqZNBIUnqZFBIkjoZFJKkTgaFJKmTQSFJ6mRQSJI6GRSSpE4GhSSpk0EhSepkUEiSOhkUkqROQwdFkouT/M8kTyc5luR3Wv38JIeTPNue1/T1uTHJRJJnkmzvq1+R5Ghbd1u7JSrttqn3t/qRJBtG+KySpCGMckRxGvgXVfV3ga3A9UkuBW4AHq6qTcDD7TVt3S7gMmAHcHuSVW1bdwB76d1He1NbD7AHOFVVlwC3AreMMF5J0hCGDoqqOl5VX2vLLwNPA+uAncCB1uwAcFVb3gncV1WvVtVzwASwJclFwLlV9VhVFXDPrD7T23oA2DZ9tCFJWhpnZI6inRL6ReAI8PaqOg69MAEubM3WAS/0dZtstXVteXZ9Rp+qOg28BFww4P33JhlPMj41NXUmPpIkqRk5KJK8FfgD4J9V1Z93NR1Qq456V5+Zhao7q2pzVW0eGxubb8iSpEUYKSiS/HV6IfGZqvpcK3+/nU6iPZ9o9Ung4r7u64EXW339gPqMPklWA+cBJ0cZsyRpcUa56inAXcDTVfXv+1YdAna35d3Ag331Xe1Kpo30Jq0fb6enXk6ytW3z2ll9prd1NfBIm8eQJC2R1SP0fR/wj4CjSZ5stX8F3AwcTLIHeB64BqCqjiU5CDxF74qp66vqtdbvOuBu4BzgofaAXhDdm2SC3pHErhHGK0kawtBBUVX/m8FzCADb5uizD9g3oD4OXD6g/gotaCRJy8NvZkuSOo1y6kln0IYbvrBs7/3dmz+wbO8taeXziEKS1MmgkCR1MigkSZ0MCklSJ4NCktTJq560bFdcebWV9PrgEYUkqZNHFFo2HslIrw8eUUiSOnlEoTccvwUvLY5BIS0hT7e9Mfyk/TkbFNIbgEdRGoVBIemsWs6Q0pnhZLYkqZNBIUnq9LoIiiQ7kjyTZCLJDcs9Hkl6I1nxQZFkFfAfgV8DLgU+lOTS5R2VJL1xrPigALYAE1X1nar6IXAfsHOZxyRJbxivh6ue1gEv9L2eBN7T3yDJXmBve/kXSZ5ZorENYy3wg+UeRAfHNxrHNxrHN4LcMtL4/vZcK14PQZEBtZrxoupO4M6lGc5okoxX1eblHsdcHN9oHN9oHN9oztb4Xg+nniaBi/terwdeXKaxSNIbzushKJ4ANiXZmORNwC7g0DKPSZLeMFb8qaeqOp3knwBfBFYB+6vq2DIPaxQr/RSZ4xuN4xuN4xvNWRlfqmr+VpKkN6zXw6knSdIyMigkSZ0MijNkvp8ZSc9tbf03k7yrb913kxxN8mSS8WUa388neSzJq0k+tpi+K2B8K2H//Vb7c/1mki8n+YWF9l0B41sJ+29nG9uTScaT/NJC+66A8S37/utr9+4kryW5erF9O1WVjxEf9CbZ/xh4B/Am4BvApbPa/DrwEL3vhWwFjvSt+y6wdpnHdyHwbmAf8LHF9F3O8a2g/fdeYE1b/rXpP98VtP8Gjm8F7b+38qM503cC315h+2/g+FbK/utr9wjw34Grz+T+84jizFjIz4zsBO6pnq8Ab0ty0UoZX1WdqKongL9cbN9lHt9SWMj4vlxVp9rLr9D7vs+C+i7z+JbCQsb3F9X+ZQPewo++VLtS9t9c41sKC90HHwX+ADgxRN9OBsWZMehnRtYtok0BX0ry1fZzJMsxvrPRd6FGfY+Vtv/20Dt6HKbvMEYZH6yQ/ZfkN5N8G/gC8NuL6buM44MVsP+SrAN+E/hPi+27ECv+exSvE/P+zMg8bd5XVS8muRA4nOTbVfXoEo/vbPRdqFHfY8XsvyS/Qu8f4ulz2Ctq/w0YH6yQ/VdVnwc+n+SXgU8Bv7rQviMaZXywMvbf7wMfr6rXkhnNz8j+84jizFjIz4zM2aaqpp9PAJ+nd7i41OM7G30XaqT3WCn7L8k7gU8DO6vqTxfTdxnHt2L2X994HgV+NsnaxfZdhvGtlP23GbgvyXeBq4Hbk1y1wL7zO1sTMG+kB70js+8AG/nRhNFls9p8gJmT2Y+3+luAv9G3/GVgx1KPr6/tv2HmZPaC+y7T+FbE/gP+FjABvHfYz7ZM41sp++8SfjRZ/C7ge+3vykrZf3ONb0Xsv1nt7+ZHk9lnZP+dsQ/zRn/Qu6rpj+hdYfCJVvsI8JG2HHo3YPpj4CiwudXf0f7wvgEcm+67DOP7GXr/+/hz4M/a8rlz9V0p41tB++/TwCngyfYY7+q7Usa3gvbfx9v7Pwk8BvzSCtt/A8e3UvbfrLZ304LiTO0/f8JDktTJOQpJUieDQpLUyaCQJHUyKCRJnQwKSVIng0KS1MmgkCR1+v+UhWnwWSEasQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(weights2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9a7e52a7",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([3.9256897e+07, 5.1050100e+05, 7.3807900e+05, 1.1851390e+06,\n",
+       "        1.4254360e+06, 1.5065640e+06, 1.1867830e+06, 5.4733300e+05,\n",
+       "        8.1162000e+04, 2.1060000e+03]),\n",
+       " array([0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1. ]),\n",
+       " <BarContainer object of 10 artists>)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEWCAYAAAB2X2wCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAUwklEQVR4nO3df6ye5X3f8fcnYNR00DiqTxtmA6YZSQesBOI5kGydm2YaEFo2iWnQNCgokgWhURo1WtNoI4uqTUSasgbc4LopSlkzaEYQpdSkQ0oZsGCSAzU/HJLWS6BYsHJCho0LTWr47o/ndnby+Jzz3Md+zq/L75f0yPeP67mf74UPH1/neu4fqSokSSvfa5a6AEnSeBjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNC1YiXZlWTTUtchLRcGupatJE8medfQtvcluR+gqs6oqntGHGN9kkpy7AKWKi0LBrp0BPyHQsuJga4Va/oIPsnGJJNJ9iX56ySf6prd2/35QpL9Sc5L8pok/y7JU0meS3JTktdNO+7l3b7nk/z7oc/5D0luTfIHSfYB7+s++4EkLyR5NsmWJMdNO14l+UCSv0zyYpLfTPLG7j37knxhenvpcBnoasWngU9X1Y8BbwS+0G3/2e7P1VV1fFU9ALyve/0c8FPA8cAWgCSnA58B3gOcCLwOWDv0WRcDtwKrgc8DrwAfBtYA5wE/D3xg6D3nA28FzgX+LbCt+4yTgDOByw6/69LAkgZ6khu7EdLjPdr+lyQ7u9dfJHlhEUrU0ru9G/m+0P2df2aWdn8H/IMka6pqf1XtmOOY7wE+VVXfqqr9wG8Al3bTJ5cAf1xV91fV94FrgOEbHj1QVbdX1atV9XJVPVRVO6rqQFU9CfwO8M+G3vPJqtpXVbuAx4H/0X3+XuAu4Oze/0WkWSz1CP1zDEYuI1XVh6vqLVX1FuB64LYFrEvLx7+sqtUHXxw68j3o/cCbgG8k+VqSi+Y45t8Hnpq2/hRwLPCT3b6nD+6oqpeA54fe//T0lSRvSnJnkv/TTcP8Jwaj9en+etryyzOsHz9HvVIvSxroVXUv8N3p27q5xS8leSjJfUl+eoa3XgbcvChFakWoqr+sqsuAnwA+Cdya5O9x6Oga4BnglGnrJwMHGITss8C6gzuSvBb48eGPG1q/AfgGcFo35fMxIIffG+nwLPUIfSbbgA9W1VuBjzD0K3aSU4BTgS8vQW1appL8cpKJqnoVeKHb/AowBbzKYK78oJuBDyc5NcnxDEbUf1hVBxjMjf9Ckrd3X1R+gtHhfAKwD9jfDUCuGle/pPlYVoHe/c/1duC/J9nJYC7yxKFmlwK3VtUri1yelrfzgV1J9jP4gvTSqvrbbsrkPwL/q5uHPxe4EfivDM6A+Tbwt8AHAbo57g8CtzAYrb8IPAd8b47P/gjwS13b3wX+cPzdk0bLUj/gIsl64M6qOjPJjwHfrKrhEJ/e/s+Bq6vqK4tVo45e3SDjBQbTKd9e4nKkOS2rEXpV7QO+neRfA2TgrIP7k7wZeD3wwBKVqKNAkl9I8qPdHPx/Bh4DnlzaqqTRlvq0xZsZhPObk+xJ8n4Gp5S9P8kjwC4G5/wedBlwSy31rxVq3cUMvjh9BjiNwfSNP3Na9pZ8ykWSNB7LaspFknT4luzGQmvWrKn169cv1cdL0or00EMPfaeqJmbat2SBvn79eiYnJ5fq4yVpRUry1Gz7nHKRpEYY6JLUiN6BnuSYJH+e5M4Z9iXJdUl2J3k0yTnjLVOSNMp8RugfAp6YZd8FDM7XPQ3YzOBmRZKkRdQr0JOsA94NfHaWJhcDN9XADmB1klkv35ckjV/fEfpvMXjKyquz7F/LD98jeg+HPuWFJJu7x4RNTk1NzadOSdIIIwO9e1DAc1X10FzNZth2yCWoVbWtqjZU1YaJiRlPo5QkHaY+I/R3AL+Y5EkGtxR9Z5I/GGqzh8GzEQ9ax+A+GJKkRTIy0KvqN6pqXVWtZ3Av8i9X1S8PNbsDuLw72+VcYG9VPTv+ciVJsznsK0WTXAlQVVuB7cCFwG7gJeCKsVQ3i/Uf/ZOFPPycnrz23Uv22ZI0l3kFelXdA9zTLW+dtr2Aq8dZmCRpfrxSVJIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhoxMtCT/EiSryZ5JMmuJJ+Yoc2mJHuT7Oxe1yxMuZKk2fR5BN33gHdW1f4kq4D7k9xVVTuG2t1XVReNv0RJUh8jA717Xuj+bnVV96qFLEqSNH+95tCTHJNkJ/AccHdVPThDs/O6aZm7kpwxy3E2J5lMMjk1NXX4VUuSDtEr0Kvqlap6C7AO2JjkzKEmDwOnVNVZwPXA7bMcZ1tVbaiqDRMTE4dftSTpEPM6y6WqXgDuAc4f2r6vqvZ3y9uBVUnWjKlGSVIPfc5ymUiyult+LfAu4BtDbd6QJN3yxu64z4+9WknSrPqc5XIi8PtJjmEQ1F+oqjuTXAlQVVuBS4CrkhwAXgYu7b5MlSQtkj5nuTwKnD3D9q3TlrcAW8ZbmiRpPrxSVJIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhrR55miP5Lkq0keSbIrySdmaJMk1yXZneTRJOcsTLmSpNn0eabo94B3VtX+JKuA+5PcVVU7prW5ADite70NuKH7U5K0SEaO0Gtgf7e6qnsNPwD6YuCmru0OYHWSE8dbqiRpLr3m0JMck2Qn8Bxwd1U9ONRkLfD0tPU93TZJ0iLpFehV9UpVvQVYB2xMcuZQk8z0tuENSTYnmUwyOTU1Ne9iJUmzm9dZLlX1AnAPcP7Qrj3ASdPW1wHPzPD+bVW1oao2TExMzK9SSdKc+pzlMpFkdbf8WuBdwDeGmt0BXN6d7XIusLeqnh13sZKk2fU5y+VE4PeTHMPgH4AvVNWdSa4EqKqtwHbgQmA38BJwxQLVK0maxchAr6pHgbNn2L512nIBV4+3NEnSfHilqCQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRvR5SPRJSf4syRNJdiX50AxtNiXZm2Rn97pmYcqVJM2mz0OiDwC/VlUPJzkBeCjJ3VX19aF291XVReMvUZLUx8gRelU9W1UPd8svAk8Aaxe6MEnS/MxrDj3JeuBs4MEZdp+X5JEkdyU5Y5b3b04ymWRyampq/tVKkmbVO9CTHA98EfjVqto3tPth4JSqOgu4Hrh9pmNU1baq2lBVGyYmJg6zZEnSTHoFepJVDML881V12/D+qtpXVfu75e3AqiRrxlqpJGlOfc5yCfB7wBNV9alZ2ryha0eSjd1xnx9noZKkufU5y+UdwHuBx5Ls7LZ9DDgZoKq2ApcAVyU5ALwMXFpVNf5yJUmzGRnoVXU/kBFttgBbxlWUJGn+vFJUkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGtHnmaInJfmzJE8k2ZXkQzO0SZLrkuxO8miScxamXEnSbPo8U/QA8GtV9XCSE4CHktxdVV+f1uYC4LTu9Tbghu5PSdIiGTlCr6pnq+rhbvlF4Alg7VCzi4GbamAHsDrJiWOvVpI0q3nNoSdZD5wNPDi0ay3w9LT1PRwa+iTZnGQyyeTU1NQ8S5UkzaV3oCc5Hvgi8KtVtW949wxvqUM2VG2rqg1VtWFiYmJ+lUqS5tQr0JOsYhDmn6+q22Zosgc4adr6OuCZIy9PktRXn7NcAvwe8ERVfWqWZncAl3dnu5wL7K2qZ8dYpyRphD5nubwDeC/wWJKd3baPAScDVNVWYDtwIbAbeAm4YuyVSpLmNDLQq+p+Zp4jn96mgKvHVZQkaf68UlSSGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSIwx0SWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiP6PCT6xiTPJXl8lv2bkuxNsrN7XTP+MiVJo/R5SPTngC3ATXO0ua+qLhpLRZKkwzJyhF5V9wLfXYRaJElHYFxz6OcleSTJXUnOmK1Rks1JJpNMTk1NjemjJUkwnkB/GDilqs4Crgdun61hVW2rqg1VtWFiYmIMHy1JOuiIA72q9lXV/m55O7AqyZojrkySNC9HHOhJ3pAk3fLG7pjPH+lxJUnzM/IslyQ3A5uANUn2AB8HVgFU1VbgEuCqJAeAl4FLq6oWrGJJ0oxGBnpVXTZi/xYGpzVKkpaQV4pKUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1wkCXpEYY6JLUCANdkhphoEtSI0YGepIbkzyX5PFZ9ifJdUl2J3k0yTnjL1OSNEqfEfrngPPn2H8BcFr32gzccORlSZLma2SgV9W9wHfnaHIxcFMN7ABWJzlxXAVKkvoZxxz6WuDpaet7um2HSLI5yWSSyampqTF8tCTpoHEEembYVjM1rKptVbWhqjZMTEyM4aMlSQeNI9D3ACdNW18HPDOG40qS5mEcgX4HcHl3tsu5wN6qenYMx5UkzcOxoxokuRnYBKxJsgf4OLAKoKq2AtuBC4HdwEvAFQtVrCRpdiMDvaouG7G/gKvHVpEk6bB4pagkNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRhjoktQIA12SGmGgS1IjDHRJaoSBLkmNMNAlqREGuiQ1olegJzk/yTeT7E7y0Rn2b0qyN8nO7nXN+EuVJM2lzzNFjwF+G/jnwB7ga0nuqKqvDzW9r6ouWoAaJUk99BmhbwR2V9W3qur7wC3AxQtbliRpvvoE+lrg6Wnre7ptw85L8kiSu5KcMdOBkmxOMplkcmpq6jDKlSTNpk+gZ4ZtNbT+MHBKVZ0FXA/cPtOBqmpbVW2oqg0TExPzKlSSNLc+gb4HOGna+jrgmekNqmpfVe3vlrcDq5KsGVuVkqSR+gT614DTkpya5DjgUuCO6Q2SvCFJuuWN3XGfH3exkqTZjTzLpaoOJPkV4E+BY4Abq2pXkiu7/VuBS4CrkhwAXgYurarhaRlJ0gIaGejwg2mU7UPbtk5b3gJsGW9pkqT58EpRSWqEgS5JjTDQJakRBrokNcJAl6RGGOiS1AgDXZIaYaBLUiMMdElqhIEuSY0w0CWpEQa6JDXCQJekRvS626K0FNZ/9E+WuoRF9+S1717qErSCOUKXpEY4QtdIR+NIeaks1X9rfzNogyN0SWqEI/QVwlGypFF6BXqS84FPM3im6Ger6tqh/en2Xwi8BLyvqh4ec63LgsGqFi3lz7XTPeMzcsolyTHAbwMXAKcDlyU5fajZBcBp3WszcMOY65QkjdBnhL4R2F1V3wJIcgtwMfD1aW0uBm6qqgJ2JFmd5MSqenbsFUtqil8Ej0+fQF8LPD1tfQ/wth5t1gI/FOhJNjMYwQPsT/LNeVX7/60BvnOY712p7PPRwT4vknxysT/xhxxJn0+ZbUefQM8M2+ow2lBV24BtPT5z7oKSyaracKTHWUns89HBPh8dFqrPfU5b3AOcNG19HfDMYbSRJC2gPoH+NeC0JKcmOQ64FLhjqM0dwOUZOBfY6/y5JC2ukVMuVXUgya8Af8rgtMUbq2pXkiu7/VuB7QxOWdzN4LTFKxauZGAM0zYrkH0+Otjno8OC9DmDE1MkSSudl/5LUiMMdElqxLIO9CTnJ/lmkt1JPjrD/iS5rtv/aJJzlqLOcerR5/d0fX00yVeSnLUUdY7TqD5Pa/ePk7yS5JLFrG8h9Olzkk1JdibZleR/LnaN49bjZ/t1Sf44ySNdnxf6u7gFleTGJM8leXyW/ePPr6pali8GX8D+b+CngOOAR4DTh9pcCNzF4Dz4c4EHl7ruRejz24HXd8sXHA19ntbuywy+gL9kqetehL/n1Qyuxj65W/+Jpa57Efr8MeCT3fIE8F3guKWu/Qj6/LPAOcDjs+wfe34t5xH6D245UFXfBw7ecmC6H9xyoKp2AKuTnLjYhY7RyD5X1Veq6v92qzsYnPO/kvX5ewb4IPBF4LnFLG6B9OnzLwG3VdVfAVTVSu93nz4XcEJ3s7/jGQT6gcUtc3yq6l4GfZjN2PNrOQf6bLcTmG+blWS+/Xk/g3/hV7KRfU6yFvhXwNZFrGsh9fl7fhPw+iT3JHkoyeWLVt3C6NPnLcA/ZHBR4mPAh6rq1cUpb0mMPb+W8/3Qx3bLgRWkd3+S/ByDQP8nC1rRwuvT598Cfr2qXhkM3la8Pn0+Fngr8PPAa4EHkuyoqr9Y6OIWSJ8+/wtgJ/BO4I3A3Unuq6p9C1zbUhl7fi3nQD8abznQqz9Jfgb4LHBBVT2/SLUtlD593gDc0oX5GuDCJAeq6vZFqXD8+v5sf6eq/gb4myT3AmcBKzXQ+/T5CuDaGkww707ybeCnga8uTomLbuz5tZynXI7GWw6M7HOSk4HbgPeu4NHadCP7XFWnVtX6qloP3Ap8YAWHOfT72f4j4J8mOTbJjzK4w+kTi1znOPXp818x+I2EJD8JvBn41qJWubjGnl/LdoRey/OWAwuqZ5+vAX4c+Ew3Yj1QK/hOdT373JQ+fa6qJ5J8CXgUeJXBk8JmPP1tJej59/ybwOeSPMZgOuLXq2rF3ko4yc3AJmBNkj3Ax4FVsHD55aX/ktSI5TzlIkmaBwNdkhphoEtSIwx0SWqEgS5JjTDQddRLsjrJB5a6DulIGejS4M6GBrpWvGV7YZG0iK4F3phkJ/B3wMvA8wyuVLyXwZWpLd8kSo3wwiId9ZKsB+6sqjOTbAK+BJwOPNUt/05V3bpkBUo9OeUiHeqr3X27XwFuZuXf0VJHCQNdOtTwr63+GqsVwUCX4EXghGnrG7u7Ar4G+DfA/UtTljQ/zqFLQJL/BvwMgy9EXwSmgH+EX4pqBTHQpWm6L0U/UlUXLXEp0rw55SJJjXCELkmNcIQuSY0w0CWpEQa6JDXCQJekRhjoktSI/wf+kC139vErxgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ds_train.mrms.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "b2d9711a",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([4.6242952e+07, 1.6890100e+05, 2.2276000e+04, 4.3350000e+03,\n",
+       "        1.0230000e+03, 3.5800000e+02, 1.0800000e+02, 3.2000000e+01,\n",
+       "        9.0000000e+00, 6.0000000e+00]),\n",
+       " array([0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1. ]),\n",
+       " <BarContainer object of 10 artists>)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAEWCAYAAABPON1ZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAPIklEQVR4nO3de4yldX3H8fdHFlIt6Bp3NBTUQapYSr1uKWprKZoUUUub2BS8RUNCWlpiTY23tLbGtIGksdpaq1tLrNWCFolVrLYmliIV1F0FZMULFVAilRW7Lut94ds/zlkdh9mdZ+FcvrPzfiWTnTPnmXO+P2Z577PPeZ6zqSokSX3dZ94DSJL2z1BLUnOGWpKaM9SS1JyhlqTmDLUkNWeo1VKS7UlOnvccUgeGWnOR5KYkT1/2tRcluQKgqn6+qi5b5TEWk1SSDVMcVZo7Qy3tg38AqAtDrZaW7nEnOTHJ1iS7knw9yevHm10+/nVnkt1JnpTkPkn+OMnNSW5L8o4kD1jyuC8c33d7kj9Z9jx/luTiJO9Msgt40fi5r0yyM8mtSd6U5LAlj1dJzknypSR3JHldkmPH37MryXuWbi/dE4Zaa8EbgTdW1f2BY4H3jL/+1PGvG6vq8Kq6EnjR+OPXgEcAhwNvAkhyPPBm4HnAkcADgKOWPdfpwMXARuBdwJ3AS4FNwJOApwHnLPueU4EnAicBLwe2jJ/jocAJwJn3fOnSFEOd5ILxHs11A7b9qyRXjz++mGTntOZSK+8b76nuHP/M37yP7X4I/GySTVW1u6qu2s9jPg94fVV9uap2A68CzhgfxngO8IGquqKqfgC8Blj+ZjdXVtX7ququqvpuVW2rqquqak9V3QS8FfjVZd9zflXtqqrtwHXAf4yf/1vAh4DHD/4vIq1gmnvUb2e0p7GqqnppVT2uqh4H/A1wyRTnUh+/WVUb935w9z3Vvc4CHgV8PsmnkjxrP4/5M8DNS27fDGwAHjK+76t776iq7wC3L/v+ry69keRRSS5N8r/jwyF/wWjveqmvL/n8uyvcPnw/80qrmlqoq+py4JtLvzY+dvfhJNuSfCzJo1f41jOBC6c1l9aeqvpSVZ0JPBg4H7g4yU9z971hgK8BD19y+2HAHkbxvBU4eu8dSe4LPGj50y27/XfA54FHjg+9vBrIPV+NdOBmfYx6C3BuVT0ReBnL/qqb5OHAMcBHZzyXGkvy/CQLVXUXsHP85TuBHcBdjI5F73Uh8NIkxyQ5nNEe8Lurag+jY8/PTvLk8Qt8r2X16B4B7AJ2j3csfm9S65KGmlmox//TPBn4lyRXMzrWd+Syzc4ALq6qO2c1l9aEU4HtSXYzemHxjKr63vjQxZ8D/z0+zn0ScAHwT4zOCLkR+B5wLsD4GPK5wEWM9q7vAG4Dvr+f534Z8Nzxtn8PvHvyy5P2L9P8hwOSLAKXVtUJSe4PfKGqlsd56fafAX6/qj4+taGksfHOw05GhzVunPM40j7NbI+6qnYBNyb5bYCMPHbv/UmOAx4IXDmrmbT+JHl2kvuNj3H/JfBZ4Kb5TiXt3zRPz7uQUXSPS3JLkrMYnTp1VpJrgO2Mzlnd60zgovLfBtN0nc7oBcevAY9kdBjF33NqbaqHPiRJ955XJkpSc1N505lNmzbV4uLiNB5akg5K27Zt+0ZVLax031RCvbi4yNatW6fx0JJ0UEpy877u89CHJDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNTeVKxPvjcVXfnAuz3vTec+cy/NK0mrco5ak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktTc4FAnOSTJZ5JcOs2BJEk/6UD2qF8CXD+tQSRJKxsU6iRHA88E3jbdcSRJyw3do34D8HLgrn1tkOTsJFuTbN2xY8ckZpMkMSDUSZ4F3FZV2/a3XVVtqarNVbV5YWFhYgNK0no3ZI/6KcBvJLkJuAg4Jck7pzqVJOlHVg11Vb2qqo6uqkXgDOCjVfX8qU8mSQI8j1qS2ttwIBtX1WXAZVOZRJK0IveoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJam7VUCf5qSSfTHJNku1JXjuLwSRJIxsGbPN94JSq2p3kUOCKJB+qqqumPJskiQGhrqoCdo9vHjr+qGkOJUn6sUHHqJMckuRq4DbgI1X1iRW2OTvJ1iRbd+zYMeExJWn9GhTqqrqzqh4HHA2cmOSEFbbZUlWbq2rzwsLChMeUpPXrgM76qKqdwGXAqdMYRpJ0d0PO+lhIsnH8+X2BpwOfn/JckqSxIWd9HAn8Y5JDGIX9PVV16XTHkiTtNeSsj2uBx89gFknSCrwyUZKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1t2qokzw0yX8muT7J9iQvmcVgkqSRDQO22QP8UVV9OskRwLYkH6mqz015NkkSA/aoq+rWqvr0+PM7gOuBo6Y9mCRp5ICOUSdZBB4PfGKF+85OsjXJ1h07dkxoPEnS4FAnORx4L/CHVbVr+f1VtaWqNlfV5oWFhUnOKEnr2qBQJzmUUaTfVVWXTHckSdJSQ876CPAPwPVV9frpjyRJWmrIHvVTgBcApyS5evxx2pTnkiSNrXp6XlVdAWQGs0iSVuCViZLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpuVVDneSCJLcluW4WA0mSftKQPeq3A6dOeQ5J0j6sGuqquhz45gxmkSStYGLHqJOcnWRrkq07duyY1MNK0ro3sVBX1Zaq2lxVmxcWFib1sJK07nnWhyQ1Z6glqbkhp+ddCFwJHJfkliRnTX8sSdJeG1bboKrOnMUgkqSVeehDkpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDU3KNRJTk3yhSQ3JHnltIeSJP3YqqFOcgjwt8AzgOOBM5McP+3BJEkjGwZscyJwQ1V9GSDJRcDpwOemOdisLb7yg3N77pvOe+bcnltSf0NCfRTw1SW3bwF+aflGSc4Gzh7f3J3kC/dwpk3AN+7h965JOX/9rZn193Neb+sF13ygHr6vO4aEOit8re72haotwJYDGGrlJ0u2VtXme/s4a4lrPvitt/WCa56kIS8m3gI8dMnto4GvTXoQSdLKhoT6U8AjkxyT5DDgDOD90x1LkrTXqoc+qmpPkj8A/h04BLigqrZPcaZ7ffhkDXLNB7/1tl5wzROTqrsdbpYkNeKViZLUnKGWpObmEurVLknPyF+P7782yRPmMeckDVjz88ZrvTbJx5M8dh5zTtLQtx5I8otJ7kzynFnONw1D1pzk5CRXJ9me5L9mPeOkDfi9/YAkH0hyzXjNL57HnJOS5IIktyW5bh/3T75fVTXTD0YvSP4P8AjgMOAa4Phl25wGfIjROdwnAZ+Y9ZxzWPOTgQeOP3/Geljzku0+Cvwb8Jx5zz2Dn/NGRlf1Pmx8+8HznnsGa341cP748wXgm8Bh8579Xqz5qcATgOv2cf/E+zWPPeofXZJeVT8A9l6SvtTpwDtq5CpgY5IjZz3oBK265qr6eFX93/jmVYzOV1/LhvycAc4F3gvcNsvhpmTImp8LXFJVXwGoqrW+7iFrLuCIJAEOZxTqPbMdc3Kq6nJGa9iXifdrHqFe6ZL0o+7BNmvJga7nLEZ/Iq9lq645yVHAbwFvmeFc0zTk5/wo4IFJLkuyLckLZzbddAxZ85uAn2N0odxngZdU1V2zGW8uJt6vIZeQT9qQS9IHXba+hgxeT5JfYxTqX57qRNM3ZM1vAF5RVXeOdrbWvCFr3gA8EXgacF/gyiRXVdUXpz3clAxZ868DVwOnAMcCH0nysaraNeXZ5mXi/ZpHqIdckn6wXbY+aD1JHgO8DXhGVd0+o9mmZciaNwMXjSO9CTgtyZ6qet9MJpy8ob+3v1FV3wa+neRy4LHAWg31kDW/GDivRgdwb0hyI/Bo4JOzGXHmJt6veRz6GHJJ+vuBF45fPT0J+FZV3TrrQSdo1TUneRhwCfCCNbx3tdSqa66qY6pqsaoWgYuBc9ZwpGHY7+1/BX4lyYYk92P0TpTXz3jOSRqy5q8w+hsESR4CHAd8eaZTztbE+zXzPeraxyXpSX53fP9bGJ0BcBpwA/AdRn8ir1kD1/wa4EHAm8d7mHtqDb/z2MA1H1SGrLmqrk/yYeBa4C7gbVW14mlea8HAn/PrgLcn+SyjwwKvqKo1+/anSS4ETgY2JbkF+FPgUJhev7yEXJKa88pESWrOUEtSc4Zakpoz1JLUnKGWpOYMtQ5aSTYmOWfec0j3lqHWwWwjYKi15s3jEnJpVs4Djk1yNfBD4LvA7YyujLuc0ZWQB/ObA+kg4QUvOmglWQQuraoTkpwMfBg4Hrh5/Plbq+riuQ0oDeShD60nnxy/b/KdwIWs/Xco1DphqLWeLP/ro3+d1JpgqHUwuwM4YsntE8fv8nYf4HeAK+YzlnRgPEatg1qSfwYew+iFxDuAHcAv4IuJWkMMtdaF8YuJL6uqZ815FOmAeehDkppzj1qSmnOPWpKaM9SS1JyhlqTmDLUkNWeoJam5/wfnYry8UxWwxAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ds_train2.mrms.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "afaa2c58",
+   "metadata": {
+    "Collapsed": "false"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",
+       "<defs>\n",
+       "<symbol id=\"icon-database\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z\"></path>\n",
+       "<path d=\"M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "<path d=\"M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "</symbol>\n",
+       "<symbol id=\"icon-file-text2\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z\"></path>\n",
+       "<path d=\"M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "</symbol>\n",
+       "</defs>\n",
+       "</svg>\n",
+       "<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.\n",
+       " *\n",
+       " */\n",
+       "\n",
+       ":root {\n",
+       "  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));\n",
+       "  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));\n",
+       "  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));\n",
+       "  --xr-border-color: var(--jp-border-color2, #e0e0e0);\n",
+       "  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);\n",
+       "  --xr-background-color: var(--jp-layout-color0, white);\n",
+       "  --xr-background-color-row-even: var(--jp-layout-color1, white);\n",
+       "  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);\n",
+       "}\n",
+       "\n",
+       "html[theme=dark],\n",
+       "body.vscode-dark {\n",
+       "  --xr-font-color0: rgba(255, 255, 255, 1);\n",
+       "  --xr-font-color2: rgba(255, 255, 255, 0.54);\n",
+       "  --xr-font-color3: rgba(255, 255, 255, 0.38);\n",
+       "  --xr-border-color: #1F1F1F;\n",
+       "  --xr-disabled-color: #515151;\n",
+       "  --xr-background-color: #111111;\n",
+       "  --xr-background-color-row-even: #111111;\n",
+       "  --xr-background-color-row-odd: #313131;\n",
+       "}\n",
+       "\n",
+       ".xr-wrap {\n",
+       "  display: block;\n",
+       "  min-width: 300px;\n",
+       "  max-width: 700px;\n",
+       "}\n",
+       "\n",
+       ".xr-text-repr-fallback {\n",
+       "  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-header {\n",
+       "  padding-top: 6px;\n",
+       "  padding-bottom: 6px;\n",
+       "  margin-bottom: 4px;\n",
+       "  border-bottom: solid 1px var(--xr-border-color);\n",
+       "}\n",
+       "\n",
+       ".xr-header > div,\n",
+       ".xr-header > ul {\n",
+       "  display: inline;\n",
+       "  margin-top: 0;\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type,\n",
+       ".xr-array-name {\n",
+       "  margin-left: 2px;\n",
+       "  margin-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-sections {\n",
+       "  padding-left: 0 !important;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 150px auto auto 1fr 20px 20px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input + label {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label {\n",
+       "  cursor: pointer;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label:hover {\n",
+       "  color: var(--xr-font-color0);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary {\n",
+       "  grid-column: 1;\n",
+       "  color: var(--xr-font-color2);\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary > span {\n",
+       "  display: inline-block;\n",
+       "  padding-left: 0.5em;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in + label:before {\n",
+       "  display: inline-block;\n",
+       "  content: '►';\n",
+       "  font-size: 11px;\n",
+       "  width: 15px;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label:before {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label:before {\n",
+       "  content: '▼';\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label > span {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary,\n",
+       ".xr-section-inline-details {\n",
+       "  padding-top: 4px;\n",
+       "  padding-bottom: 4px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-inline-details {\n",
+       "  grid-column: 2 / -1;\n",
+       "}\n",
+       "\n",
+       ".xr-section-details {\n",
+       "  display: none;\n",
+       "  grid-column: 1 / -1;\n",
+       "  margin-bottom: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked ~ .xr-section-details {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap {\n",
+       "  grid-column: 1 / -1;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 20px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap > label {\n",
+       "  grid-column: 1;\n",
+       "  vertical-align: top;\n",
+       "}\n",
+       "\n",
+       ".xr-preview {\n",
+       "  color: var(--xr-font-color3);\n",
+       "}\n",
+       "\n",
+       ".xr-array-preview,\n",
+       ".xr-array-data {\n",
+       "  padding: 0 5px !important;\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-array-data,\n",
+       ".xr-array-in:checked ~ .xr-array-preview {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-array-in:checked ~ .xr-array-data,\n",
+       ".xr-array-preview {\n",
+       "  display: inline-block;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list {\n",
+       "  display: inline-block !important;\n",
+       "  list-style: none;\n",
+       "  padding: 0 !important;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li {\n",
+       "  display: inline-block;\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:before {\n",
+       "  content: '(';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:after {\n",
+       "  content: ')';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li:not(:last-child):after {\n",
+       "  content: ',';\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-has-index {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list,\n",
+       ".xr-var-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > div,\n",
+       ".xr-var-item label,\n",
+       ".xr-var-item > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-even);\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > .xr-var-name:hover span {\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list > li:nth-child(odd) > div,\n",
+       ".xr-var-list > li:nth-child(odd) > label,\n",
+       ".xr-var-list > li:nth-child(odd) > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-odd);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name {\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dims {\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dtype {\n",
+       "  grid-column: 3;\n",
+       "  text-align: right;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-preview {\n",
+       "  grid-column: 4;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name,\n",
+       ".xr-var-dims,\n",
+       ".xr-var-dtype,\n",
+       ".xr-preview,\n",
+       ".xr-attrs dt {\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name:hover,\n",
+       ".xr-var-dims:hover,\n",
+       ".xr-var-dtype:hover,\n",
+       ".xr-attrs dt:hover {\n",
+       "  overflow: visible;\n",
+       "  width: auto;\n",
+       "  z-index: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data {\n",
+       "  display: none;\n",
+       "  background-color: var(--xr-background-color) !important;\n",
+       "  padding-bottom: 5px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in:checked ~ .xr-var-attrs,\n",
+       ".xr-var-data-in:checked ~ .xr-var-data {\n",
+       "  display: block;\n",
+       "}\n",
+       "\n",
+       ".xr-var-data > table {\n",
+       "  float: right;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name span,\n",
+       ".xr-var-data,\n",
+       ".xr-attrs {\n",
+       "  padding-left: 25px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs,\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data {\n",
+       "  grid-column: 1 / -1;\n",
+       "}\n",
+       "\n",
+       "dl.xr-attrs {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 125px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt,\n",
+       ".xr-attrs dd {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  float: left;\n",
+       "  padding-right: 10px;\n",
+       "  width: auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt {\n",
+       "  font-weight: normal;\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt:hover span {\n",
+       "  display: inline-block;\n",
+       "  background: var(--xr-background-color);\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dd {\n",
+       "  grid-column: 2;\n",
+       "  white-space: pre-wrap;\n",
+       "  word-break: break-all;\n",
+       "}\n",
+       "\n",
+       ".xr-icon-database,\n",
+       ".xr-icon-file-text2 {\n",
+       "  display: inline-block;\n",
+       "  vertical-align: middle;\n",
+       "  width: 1em;\n",
+       "  height: 1.5em !important;\n",
+       "  stroke-width: 0;\n",
+       "  stroke: currentColor;\n",
+       "  fill: currentColor;\n",
+       "}\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:    ()\n",
+       "Coordinates:\n",
+       "    lead_time  timedelta64[ns] 12:00:00\n",
+       "Data variables:\n",
+       "    tp         float64 9.801</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4705b181-9b23-4e85-a8a2-8cc074c0e71e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4705b181-9b23-4e85-a8a2-8cc074c0e71e' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-dd905966-f493-48c5-b762-29db09dbef16' class='xr-section-summary-in' type='checkbox'  checked><label for='section-dd905966-f493-48c5-b762-29db09dbef16' class='xr-section-summary' >Coordinates: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>lead_time</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>timedelta64[ns]</div><div class='xr-var-preview xr-preview'>12:00:00</div><input id='attrs-6c298667-e07a-4011-9c56-939e1569630a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6c298667-e07a-4011-9c56-939e1569630a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bdf1b9e6-f462-4cff-965b-ed6574b9eb27' class='xr-var-data-in' type='checkbox'><label for='data-bdf1b9e6-f462-4cff-965b-ed6574b9eb27' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Forecast offset from initial time</dd></dl></div><div class='xr-var-data'><pre>array(43200000000000, dtype=&#x27;timedelta64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4d69ecca-3fc0-4f19-813e-7f51c4777e34' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4d69ecca-3fc0-4f19-813e-7f51c4777e34' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>tp</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.801</div><input id='attrs-869b2176-2646-416e-ba0d-88d95783cdc7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-869b2176-2646-416e-ba0d-88d95783cdc7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-24df8654-f5a1-4844-862c-cea99b3d6daf' class='xr-var-data-in' type='checkbox'><label for='data-24df8654-f5a1-4844-862c-cea99b3d6daf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array(9.80099106)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0fd5e2eb-0bba-4a9e-aa6c-b7123c260b48' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-0fd5e2eb-0bba-4a9e-aa6c-b7123c260b48' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:    ()\n",
+       "Coordinates:\n",
+       "    lead_time  timedelta64[ns] 12:00:00\n",
+       "Data variables:\n",
+       "    tp         float64 9.801"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds_train.maxs"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
-   "id": "9a7e6f69",
+   "id": "62de3f20",
    "metadata": {
     "Collapsed": "false"
    },
@@ -90,7 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "6968ecc2",
+   "id": "30d8efd8",
    "metadata": {
     "Collapsed": "false"
    },
@@ -102,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": 100,
-   "id": "2a0cbb96",
+   "id": "6193f3b7",
    "metadata": {
     "Collapsed": "false"
    },
@@ -131,7 +872,7 @@
   {
    "cell_type": "code",
    "execution_count": 99,
-   "id": "fe2e4e1b",
+   "id": "b3193a04",
    "metadata": {
     "Collapsed": "false"
    },
@@ -206,7 +947,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2cf5838",
+   "id": "3ccd726d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -218,7 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "id": "6c345132",
+   "id": "a410eb3c",
    "metadata": {
     "Collapsed": "false"
    },
@@ -247,7 +988,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "c67f87b5",
+   "id": "4733b999",
    "metadata": {
     "Collapsed": "false"
    },
@@ -270,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "70faeb1e",
+   "id": "1092b3f6",
    "metadata": {
     "Collapsed": "false"
    },
@@ -295,7 +1036,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "006f3801",
+   "id": "cb771e42",
    "metadata": {
     "Collapsed": "false"
    },
@@ -320,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "9e69b795",
+   "id": "6897640a",
    "metadata": {
     "Collapsed": "false"
    },
@@ -344,7 +1085,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "2c2aef62",
+   "id": "ac47f65b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -367,7 +1108,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "841552f0",
+   "id": "ac4db594",
    "metadata": {
     "Collapsed": "false"
    },
@@ -390,7 +1131,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "37c6156a",
+   "id": "a425d61c",
    "metadata": {
     "Collapsed": "false"
    },
@@ -402,7 +1143,7 @@
   {
    "cell_type": "code",
    "execution_count": 83,
-   "id": "dcf7a295",
+   "id": "c7c2e787",
    "metadata": {
     "Collapsed": "false"
    },
@@ -414,7 +1155,7 @@
   {
    "cell_type": "code",
    "execution_count": 85,
-   "id": "431fed1b",
+   "id": "97cd8faf",
    "metadata": {
     "Collapsed": "false"
    },
@@ -426,7 +1167,7 @@
   {
    "cell_type": "code",
    "execution_count": 86,
-   "id": "22fc3944",
+   "id": "f6560d6d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -440,7 +1181,7 @@
   {
    "cell_type": "code",
    "execution_count": 87,
-   "id": "22961add",
+   "id": "27c130d0",
    "metadata": {
     "Collapsed": "false"
    },
@@ -469,7 +1210,7 @@
   {
    "cell_type": "code",
    "execution_count": 84,
-   "id": "f783519b",
+   "id": "be920c17",
    "metadata": {
     "Collapsed": "false"
    },
@@ -504,7 +1245,7 @@
   {
    "cell_type": "code",
    "execution_count": 88,
-   "id": "32643351",
+   "id": "201bc9b5",
    "metadata": {
     "Collapsed": "false"
    },
@@ -516,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": 89,
-   "id": "04f56bae",
+   "id": "7fcac4fd",
    "metadata": {
     "Collapsed": "false"
    },
@@ -539,7 +1280,7 @@
   {
    "cell_type": "code",
    "execution_count": 90,
-   "id": "1cf6928a",
+   "id": "78a9e632",
    "metadata": {
     "Collapsed": "false"
    },
@@ -553,7 +1294,7 @@
   {
    "cell_type": "code",
    "execution_count": 91,
-   "id": "4ae33cac",
+   "id": "446b36cc",
    "metadata": {
     "Collapsed": "false"
    },
@@ -576,7 +1317,7 @@
   {
    "cell_type": "code",
    "execution_count": 92,
-   "id": "e5962c89",
+   "id": "60ac0796",
    "metadata": {
     "Collapsed": "false"
    },
@@ -603,7 +1344,7 @@
   {
    "cell_type": "code",
    "execution_count": 93,
-   "id": "4471e2cc",
+   "id": "b623caf4",
    "metadata": {
     "Collapsed": "false"
    },
@@ -626,7 +1367,7 @@
   {
    "cell_type": "code",
    "execution_count": 94,
-   "id": "159cdc69",
+   "id": "e3e70a5e",
    "metadata": {
     "Collapsed": "false"
    },
@@ -661,7 +1402,7 @@
   {
    "cell_type": "code",
    "execution_count": 95,
-   "id": "0026a837",
+   "id": "2695a040",
    "metadata": {
     "Collapsed": "false"
    },
@@ -696,7 +1437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d78d0bdf",
+   "id": "3a4adc73",
    "metadata": {
     "Collapsed": "false"
    },
@@ -706,7 +1447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "366b7963",
+   "id": "88d75c4e",
    "metadata": {
     "Collapsed": "false"
    },
@@ -716,7 +1457,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "709ac68d",
+   "id": "d901a73b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -820,7 +1561,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "dfca875c",
+   "id": "5cd0fd59",
    "metadata": {
     "Collapsed": "false"
    },
@@ -844,7 +1585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93fc96db",
+   "id": "0c8181c6",
    "metadata": {
     "Collapsed": "false"
    },
@@ -854,7 +1595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a7c214a",
+   "id": "4b187983",
    "metadata": {
     "Collapsed": "false"
    },
@@ -864,7 +1605,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "fa38e515",
+   "id": "e9192e84",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1365,7 +2106,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f2cdcf5e",
+   "id": "0978ec5f",
    "metadata": {
     "Collapsed": "false"
    },
@@ -1797,7 +2538,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "3ec6a4a0",
+   "id": "1a2747ba",
    "metadata": {
     "Collapsed": "false",
     "collapsed": true,
@@ -2216,7 +2957,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "9ae3ab8e",
+   "id": "b839c0b6",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2239,7 +2980,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "bac0d62c",
+   "id": "d4be90c0",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2262,7 +3003,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "cd7dc2c2",
+   "id": "b654f8cb",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2285,7 +3026,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "63a1e81a",
+   "id": "50ee667a",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2308,7 +3049,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "151238d7",
+   "id": "c1b54330",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2323,7 +3064,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "e9b3fe86",
+   "id": "c39dc180",
    "metadata": {
     "Collapsed": "false"
    },
@@ -2746,7 +3487,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "19564cea",
+   "id": "e789511b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3169,7 +3910,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "d3f0e77b",
+   "id": "4d175d73",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3182,7 +3923,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "id": "6be03f83",
+   "id": "ddfd14db",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3195,7 +3936,7 @@
   {
    "cell_type": "code",
    "execution_count": 73,
-   "id": "86554d9e",
+   "id": "9208427f",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3208,7 +3949,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "47711274",
+   "id": "d0b066d4",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3243,7 +3984,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "84e40498",
+   "id": "ea357e85",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3278,7 +4019,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "04ce4f28",
+   "id": "14daaf8b",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3313,7 +4054,7 @@
   {
    "cell_type": "code",
    "execution_count": 74,
-   "id": "58fe9784",
+   "id": "21145722",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3348,7 +4089,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "e84822dd",
+   "id": "70479a9f",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3753,7 +4494,7 @@
   {
    "cell_type": "code",
    "execution_count": 84,
-   "id": "d95b9384",
+   "id": "adf6c10d",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3765,7 +4506,7 @@
   {
    "cell_type": "code",
    "execution_count": 79,
-   "id": "a278b5ae",
+   "id": "8b1d46f4",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3777,7 +4518,7 @@
   {
    "cell_type": "code",
    "execution_count": 85,
-   "id": "2b8cd3db",
+   "id": "0a8d0e68",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3789,7 +4530,7 @@
   {
    "cell_type": "code",
    "execution_count": 86,
-   "id": "ead68caf",
+   "id": "25e0f2dc",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3801,7 +4542,7 @@
   {
    "cell_type": "code",
    "execution_count": 83,
-   "id": "935b005e",
+   "id": "3af654e6",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3824,7 +4565,7 @@
   {
    "cell_type": "code",
    "execution_count": 87,
-   "id": "8a222b9c",
+   "id": "29fc8e87",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3847,7 +4588,7 @@
   {
    "cell_type": "code",
    "execution_count": 89,
-   "id": "abc37a40",
+   "id": "4db41b9f",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3872,7 +4613,7 @@
   {
    "cell_type": "code",
    "execution_count": 97,
-   "id": "3c95103a",
+   "id": "4553b452",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3884,7 +4625,7 @@
   {
    "cell_type": "code",
    "execution_count": 102,
-   "id": "d8691a4c",
+   "id": "2ba61fa2",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3896,7 +4637,7 @@
   {
    "cell_type": "code",
    "execution_count": 103,
-   "id": "aaf891f1",
+   "id": "154f45ba",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3919,7 +4660,7 @@
   {
    "cell_type": "code",
    "execution_count": 104,
-   "id": "24171245",
+   "id": "b51753cf",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3954,7 +4695,7 @@
   {
    "cell_type": "code",
    "execution_count": 101,
-   "id": "224254e0",
+   "id": "30d4b4b3",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3989,7 +4730,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "275cc747",
+   "id": "2b9e6da7",
    "metadata": {
     "Collapsed": "false"
    },
@@ -3999,7 +4740,7 @@
   {
    "cell_type": "code",
    "execution_count": 78,
-   "id": "c3912e05",
+   "id": "8a38ad3e",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4034,7 +4775,7 @@
   {
    "cell_type": "code",
    "execution_count": 105,
-   "id": "4ac2ba7c",
+   "id": "f76ba2fa",
    "metadata": {
     "Collapsed": "false"
    },
@@ -4061,7 +4802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60652687",
+   "id": "ac330497",
    "metadata": {
     "Collapsed": "false"
    },

--- a/notebooks/stephan_notebooks/Experiments_Categorical/07-UV.ipynb
+++ b/notebooks/stephan_notebooks/Experiments_Categorical/07-UV.ipynb
@@ -3,8 +3,10 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "609c1692",
-   "metadata": {},
+   "id": "53f8ae58",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -14,8 +16,10 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a9e75bab",
-   "metadata": {},
+   "id": "cd7d4b09",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "import xarray as xr\n",
@@ -33,8 +37,10 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "049e3ebc",
-   "metadata": {},
+   "id": "91335f6c",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "from src.dataloader import *\n",
@@ -46,8 +52,10 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8445d283",
-   "metadata": {},
+   "id": "85f24fdc",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "DATADRIVE = '/datadrive_ssd/'"
@@ -56,8 +64,10 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d937e518",
-   "metadata": {},
+   "id": "82101c19",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -78,8 +88,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff8df090",
-   "metadata": {},
+   "id": "57e15605",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "## Load data"
    ]
@@ -87,8 +99,10 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "2a6943b7",
-   "metadata": {},
+   "id": "95bdfa0b",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -132,8 +146,10 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c83bd488",
-   "metadata": {},
+   "id": "ae2e7a07",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -179,8 +195,10 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4b6f8533",
-   "metadata": {},
+   "id": "2957c639",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "sampler_train = torch.utils.data.WeightedRandomSampler(ds_train.compute_weights(\n",
@@ -194,8 +212,10 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c4a886d5",
-   "metadata": {},
+   "id": "1c9ca435",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "dl_train = torch.utils.data.DataLoader(ds_train, batch_size=16, sampler=sampler_train)\n",
@@ -205,8 +225,10 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "7f9538fa",
-   "metadata": {},
+   "id": "8df916d8",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -226,8 +248,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "283d0e86",
-   "metadata": {},
+   "id": "8e32f261",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "source": [
     "## Model"
    ]
@@ -235,8 +259,10 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "7f32b9d1",
-   "metadata": {},
+   "id": "71e575fd",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -256,8 +282,10 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "1257e3b5",
-   "metadata": {},
+   "id": "d031a318",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "gen = Generator(\n",
@@ -269,8 +297,10 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "c15c117c",
-   "metadata": {},
+   "id": "79678d6a",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -290,8 +320,10 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "30a37899",
-   "metadata": {},
+   "id": "04629925",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "criterion = nn.CrossEntropyLoss()\n",
@@ -301,8 +333,10 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "bc65c7b7",
-   "metadata": {},
+   "id": "234e2b98",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "trainer = Trainer(gen, optimizer, criterion, dl_train, dl_valid)"
@@ -311,8 +345,10 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "854ec323",
-   "metadata": {},
+   "id": "8cce48c3",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -449,8 +485,10 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "f5327eae",
-   "metadata": {},
+   "id": "963d9eb6",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -472,8 +510,10 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "4a479e08",
-   "metadata": {},
+   "id": "7a9476fa",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "import pickle\n",
@@ -484,8 +524,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2579d56",
-   "metadata": {},
+   "id": "eebc9e66",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "import pickle\n",
@@ -496,8 +538,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0de3525d",
-   "metadata": {},
+   "id": "e36b4a79",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "trainer.plot_losses()"
@@ -506,8 +550,10 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "id": "a5de116d",
-   "metadata": {},
+   "id": "7a3c0def",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "X, y = next(iter(dl_train))"
@@ -516,8 +562,10 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "id": "92a1296b",
-   "metadata": {},
+   "id": "ea7c3dd2",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "preds = nn.functional.softmax(trainer.model(X.to(device)), dim=1).cpu().detach().numpy()"
@@ -526,8 +574,10 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "id": "81f3b8e1",
-   "metadata": {},
+   "id": "20fd0261",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -547,8 +597,10 @@
   {
    "cell_type": "code",
    "execution_count": 70,
-   "id": "9944c44e",
-   "metadata": {},
+   "id": "21b9afde",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": [
     "target = y.cpu().detach().numpy()"
@@ -557,8 +609,10 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "id": "5418ba49",
-   "metadata": {},
+   "id": "9c3e98d6",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -578,8 +632,10 @@
   {
    "cell_type": "code",
    "execution_count": 124,
-   "id": "a5cad020",
-   "metadata": {},
+   "id": "648897b3",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -615,8 +671,10 @@
   {
    "cell_type": "code",
    "execution_count": 125,
-   "id": "c994b7d6",
-   "metadata": {},
+   "id": "6e463f2c",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -639,8 +697,10 @@
   {
    "cell_type": "code",
    "execution_count": 126,
-   "id": "18371486",
-   "metadata": {},
+   "id": "afa8c4ce",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -673,8 +733,10 @@
   {
    "cell_type": "code",
    "execution_count": 127,
-   "id": "74b6ff86",
-   "metadata": {},
+   "id": "c125a8fa",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [
     {
      "data": {
@@ -707,8 +769,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75d092ca",
-   "metadata": {},
+   "id": "0cba4070",
+   "metadata": {
+    "Collapsed": "false"
+   },
    "outputs": [],
    "source": []
   }

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -319,7 +319,6 @@ class TiggeMRMSDataset(Dataset):
         #     X, y = self.__getitem__(idx, no_cat=True)
         #     mean_precip.append(y.mean())
         # weights = np.clip(mean_precip, 0.01, 0.1)
-        import pdb; pdb.set_trace()
         if self.tp_log: 
             threshold = log_trans(threshold, self.tp_log)
             if self.cat_bins is None:

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -89,11 +89,11 @@ class TiggeMRMSDataset(Dataset):
         self.tigge.load(); self.mrms.load()   # Load datasets into RAM
         if tp_log:
             self.tigge['tp'] = log_trans(self.tigge['tp'], tp_log)
-            if cat_bins is None:   # No log transform for categorical output
+            if self.cat_bins is None:   # No log transform for categorical output
                 self.mrms = log_trans(self.mrms, tp_log)
         
         if scale:   # Apply min-max scaling
-            self._scale(mins, maxs, scale_mrms=True if cat_bins is None else False)
+            self._scale(mins, maxs, scale_mrms=True if self.cat_bins is None else False)
           
         # Doing this here saves time
         self.tigge = self.tigge.to_array()
@@ -319,8 +319,11 @@ class TiggeMRMSDataset(Dataset):
         #     X, y = self.__getitem__(idx, no_cat=True)
         #     mean_precip.append(y.mean())
         # weights = np.clip(mean_precip, 0.01, 0.1)
-
-        if self.tp_log: threshold = log_trans(threshold, self.tp_log)
+        import pdb; pdb.set_trace()
+        if self.tp_log: 
+            threshold = log_trans(threshold, self.tp_log)
+            if self.cat_bins is None:
+                threshold = threshold / self.maxs.tp
         assert compute_on_X == False, 'Not implemented.'
         
         coverage = (self.mrms > threshold)[:, ::-1, ::-1].rolling(


### PR DESCRIPTION
I did not account for the min/max scaling for the threshold that is used to compute the coverage. Now fixed.